### PR TITLE
Requested fixes

### DIFF
--- a/Contents/mods/LightestRankings/media/lua/client/ISGSBQoLRankingsScoreboard.lua
+++ b/Contents/mods/LightestRankings/media/lua/client/ISGSBQoLRankingsScoreboard.lua
@@ -197,8 +197,12 @@ function ISRankingScoreboardItemListBox:formatLifetime(hours)
     formattedTime = append(formattedTime, years, "y")
     formattedTime = append(formattedTime, remainingMonths, "m")
     formattedTime = append(formattedTime, remainingDays, "d")
-    formattedTime = append(formattedTime, remainingHours, "h")
-    formattedTime = append(formattedTime, remainingMinutes, "min")
+    if months < 1 then
+        formattedTime = append(formattedTime, remainingHours, "h")
+    end
+    if days < 1 then
+        formattedTime = append(formattedTime, remainingMinutes, "min")
+    end
 
     return formattedTime
 end

--- a/Contents/mods/LightestRankings/media/lua/server/GSBQoLRankingsServerCommands.lua
+++ b/Contents/mods/LightestRankings/media/lua/server/GSBQoLRankingsServerCommands.lua
@@ -60,8 +60,6 @@ function Server.Commands.DeathKillsCount(player, args)
 
     Server.data.players[userName] = record
     Server.saveData()
-
-    Server.broadcastScoreboard()
 end
 
 function Server.Commands.IgnorePlayers(player, args)

--- a/Contents/mods/LightestRankings/media/sandbox-options.txt
+++ b/Contents/mods/LightestRankings/media/sandbox-options.txt
@@ -8,7 +8,7 @@ option GSBQoLRanking.ListCap
 
 option GSBQoLRanking.BroadcastInterval
 {
-	type = integer, default = 6, min = 1, max = 168,
+	type = integer, default = 4, min = 1, max = 168,
 	page = GSBQoLRanking, translation = GSBQoLRankingBroadcastInterval,
 }
 

--- a/Contents/mods/LightestRankings/media/sandbox-options.txt
+++ b/Contents/mods/LightestRankings/media/sandbox-options.txt
@@ -8,7 +8,7 @@ option GSBQoLRanking.ListCap
 
 option GSBQoLRanking.BroadcastInterval
 {
-	type = integer, default = 24, min = 1, max = 168,
+	type = integer, default = 6, min = 1, max = 168,
 	page = GSBQoLRanking, translation = GSBQoLRankingBroadcastInterval,
 }
 


### PR DESCRIPTION
- Removes on player death broadcast
- Lowers default broadcast rate from every 24 in game hours to every 4 in game hours to account for no longer broadcasting on player death
- Removes hours from time display when greater than 1 month
- Removes minutes from time display when greater than 1 day